### PR TITLE
cuda-cuobjdump v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -169,7 +169,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-cuobjdump-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-cuobjdump" %}
-{% set version = "13.1.80" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -14,9 +14,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cuobjdump/{{ platform }}/cuda_cuobjdump-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 3de0169fd8d00e8bdd5ec91a6eb89a78229d82e478cb85554f89748107ba928c  # [linux64]
-  sha256: 3bdb14c4933a6460cd83f7ccedcb1e14df830fe79ed057dd378e9df96014d349  # [aarch64]
-  sha256: 4857f9965e1d22178fb4a1394278169d743f84c599116920f5f2468eaf734fa0  # [win]
+  sha256: ead244f805ce4616bcc9ecb5b6d993926522b825cfc1dcfff0b1113b6ac656d9  # [linux64]
+  sha256: 65677a220d5ef07c9ddd6c746ef98a2617fbd58eb0e3d045d8d9cd76ee556cce  # [aarch64]
+  sha256: ae5b23c86a7d08365c7fcb5a3e6d3c988ba76005c30cb6aab6ddf2e0dc4d9f56  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-cuobjdump" %}
-{% set version = "13.0.85" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.80" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -14,9 +14,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cuobjdump/{{ platform }}/cuda_cuobjdump-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: bd624dcb2089842add8f293efab1d21aa076c98b36d8dcb64347fe08fb03315d  # [linux64]
-  sha256: cd0304f70ff905421da2ca0fe53cfc384baa48d6ff6b34f92a80cf723064e827  # [aarch64]
-  sha256: cddbc524dc229c708cc989e4ff2d636ba342c695e0f60c1026a1b5f76de4b77b  # [win]
+  sha256: 3de0169fd8d00e8bdd5ec91a6eb89a78229d82e478cb85554f89748107ba928c  # [linux64]
+  sha256: 3bdb14c4933a6460cd83f7ccedcb1e14df830fe79ed057dd378e9df96014d349  # [aarch64]
+  sha256: 4857f9965e1d22178fb4a1394278169d743f84c599116920f5f2468eaf734fa0  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-cuobjdump 13.1.115

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-12023](https://anaconda.atlassian.net/browse/PKG-12023) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12023]: https://anaconda.atlassian.net/browse/PKG-12023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ